### PR TITLE
Added Dependabot and Github Workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+      
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/assign.yml
+++ b/.github/workflows/assign.yml
@@ -1,0 +1,24 @@
+name: Assign
+
+on:
+  schedule:
+    - cron:  0 0 * * *
+  issue_comment:
+    types: [created]
+
+jobs:
+  slash_assign:
+    # If the acton was triggered by a new comment that starts with `/assign`
+    # or a on a schedule
+    if: >
+      (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '/assign')) ||
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assign the user or unassign stale assignments
+        uses: JasonEtco/slash-assign-action@v0.0.3
+        with:
+          assigned_label: Assigned
+          days_until_warning: 7
+          days_until_unassign: 7
+          pin_label: WIP


### PR DESCRIPTION
PR allows Dependabot to check for newer version of packets, once every weekday, for pip and github-actions
Partially solves #4